### PR TITLE
Add delay=2 to uri command for slow network

### DIFF
--- a/roles/vault/tasks/vault.yml
+++ b/roles/vault/tasks/vault.yml
@@ -20,6 +20,7 @@
     url: "https://{{ vault_vip_url }}:8200/v1/sys/init"
   register: vault_init_status
   retries: 10
+  delay: 2
 
 - name: Initialize vault
   command: "docker exec -e 'VAULT_ADDR=https://{{ vault_vip_url }}:8200' {{ vault_docker_name }} vault operator init -format yaml"


### PR DESCRIPTION
Sometimes network takes a long time to be ready, and `uri` can do 10 requests very quickly without some delay.